### PR TITLE
Fix snmp_open() failing on some versions of net-snmp

### DIFF
--- a/src/nm_snmp.c
+++ b/src/nm_snmp.c
@@ -695,18 +695,6 @@ static int nm_snmp_gettrapd(lua_State *L)
   return 1;
 }
 
-static void nm_snmp_init_session(netsnmp_session *session)
-{
-  memset(session, 0, sizeof(netsnmp_session));
-  session->remote_port = SNMP_DEFAULT_REMPORT;
-  session->timeout = SNMP_DEFAULT_TIMEOUT;
-  session->retries = SNMP_DEFAULT_RETRIES;
-  session->version = SNMP_DEFAULT_VERSION;
-  session->securityModel = SNMP_DEFAULT_SECMODEL;
-  session->rcvMsgMaxSize = SNMP_MAX_MSG_SIZE;
-  session->flags |= SNMP_FLAGS_DONT_PROBE;
-}
-
 /*-----------------------------------------------------------------------------
  *  nm_snmp_open
  *
@@ -731,10 +719,7 @@ static int nm_snmp_open(lua_State *L) {
   }
 
   /* Base parameters for the session */
-#ifdef REMOVE_THIS
-  memset((char *)&nm_cmu_session,0,sizeof(CmuSession));
-#endif
-  nm_snmp_init_session(&nm_cmu_session);
+  snmp_sess_init(&nm_cmu_session);
   lua_pushstring(L, "version");
   lua_gettable(L, -2);
   version = lua_tonumber(L, -1);


### PR DESCRIPTION
In nm_snmp_open(), call to snmp_open() fails on net-snmp 5.8. Turns out
this is caused by the memset(session, 0, ...) call in
nm_snmp_init_session().

The patch removes nm_snmp_init_session() since it was only used in
nm_snmp_open() and calls snmp_sess_init() instead, which does the same
but also initializes struct member sndMsgMaxSize.

I think this should fix issue hleuwer/luasnmp#1